### PR TITLE
Use the new "commonmark-extension" package type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ows/commonmark-sup-sub-extensions",
-  "type": "library",
+  "type": "commonmark-extension",
   "description": "A sup/sub extension for CommonMark PHP implementation",
   "keywords": ["markdown","parser","commonmark"],
   "homepage": "https://github.com/ows/commonmark-sup-sub-extensions",


### PR DESCRIPTION
This makes it easier for people to find extensions on Packagist: https://packagist.org/packages/league/commonmark-ext-autolink?type=commonmark-extension