### PR TITLE
Expand test coverage for sup.

### DIFF
--- a/tests/functional/SupSubTest.php
+++ b/tests/functional/SupSubTest.php
@@ -31,7 +31,18 @@ class SupSubTest extends TestCase {
    */
   public function supMarkupProvider() {
     return [
+      // Check standard operation.
       ['10^2^', '<p>10<sup>2</sup></p>'],
+      // Check that escaping works correctly.
+      ['a^b\^c^', '<p>a<sup>b^c</sup></p>'],
+      // Ensure that sup and em can be nested properly.
+      ['*a^b^c*', '<p><em>a<sup>b</sup>c</em></p>'],
+      ['^a*b*^', '<p><sup>a<em>b</em></sup></p>'],
+      // Ensure that sup and links play nicely together.
+      ['^[a](https://example.com)^', '<p><sup><a href="https://example.com">a</a></sup></p>'],
+      ['[a^b^](https://example.com)', '<p><a href="https://example.com">a<sup>b</sup></a></p>'],
+      // Ensure that sup and header can be used together
+      ['# a^b^', '<h1>a<sup>b</sup></h1>'],
     ];
   }
 


### PR DESCRIPTION
Now that #8 is in, let's add a bunch of tests. Note: until #9 is merged, a lot of them fail.

Things to consider: right now I'm only adding tests for `<sup>` in this ; given that the implementation is exactly the same, testing both `<sup>` and `<sub>` is pointless, having a single test for `<sub>` is enough. That being said, we could add it to `<sub>` too in case the implementation starts to differ at some point.